### PR TITLE
safety and cleanup.

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -16,7 +16,7 @@
     }
   ],
   "name": "pltraining-classroomdemo",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "author": "pltraining",
   "summary": "Just a collections of classroom demos",
   "license": "Apache 2.0",


### PR DESCRIPTION
This commit does two things:
- requires creator and key_pair to ensure that instances are never
  created in a state that's difficult to recover from or might cause
  collisions with other instructors.
- accepts an `ensure` parameter with two values accepted, `absent`, and
  `present`. This will automate cleanup after the demo.

@carthik how do you like all the `absent` relationships?!

TRAINTECH-235 #resolved
