### PR TITLE
Change example so the demo works faster

### DIFF
--- a/examples/aws.pp
+++ b/examples/aws.pp
@@ -1,1 +1,10 @@
-include classroomdemo::aws
+# REPLACE yourname, yourkeypair, and the aws_region with your info!!
+class { 'classroomdemo::aws':
+     creator => 'yourname',
+     key_pair => 'yourkeypair',
+     ensure      => present,
+     pe_version  => '2016.2.1',
+     pe_username => 'admin',
+     pe_password => 'puppetlabs',
+     aws_region  => 'us-west-2',
+}


### PR DESCRIPTION
The demo has been updated to create a PE master on AWS, in a permissive
security group.
The earlier demo had issues:
1. The VPC's creation took time to complete, leading to the failure to
manage other resources that depends on the VPC existing
2. See https://github.com/puppetlabs/puppetlabs-aws/issues/137
3. See https://github.com/puppetlabs/puppetlabs-aws/issues/346